### PR TITLE
Append name to visited list

### DIFF
--- a/src/lib/ts/runtime/Ancestry.ts
+++ b/src/lib/ts/runtime/Ancestry.ts
@@ -41,6 +41,7 @@ export default class Ancestry extends Identifiable {
 	async async_traverse(apply_closureTo: (ancestry: Ancestry) => Promise<boolean>, t_kinship: T_Kinship = T_Kinship.children, visited: string[] = []) {
 		const id = this.thing?.id;
 		if (!!id && !visited.includes(id)) {
+			visited.push(this.thing?.title || '');
 			try {
 				if (!await apply_closureTo(this)) {
 					for (const progeny of this.ancestries_createUnique_byKinship(t_kinship)) {


### PR DESCRIPTION
Append the thing's title to the `visited` array during ancestry traversal to track visited items by name.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2748d1e-210a-4b50-8f33-0418defc50c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2748d1e-210a-4b50-8f33-0418defc50c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>