### PR TITLE
Prevent background click when item is clicked

### DIFF
--- a/src/lib/svelte/graph/Graph.svelte
+++ b/src/lib/svelte/graph/Graph.svelte
@@ -57,9 +57,9 @@
 		}
 	}
 	
-	function handle_mouseDown(event: MouseEvent) {
+	function handle_pointerDown(event: PointerEvent) {
 		const target = event.target as HTMLElement;
-		if (!target.closest('button, input, .mouse-responder')) {
+		if (!target.closest('button, input, .mouse-responder, .widget, .tree-preferences')) {
 			rubberbandComponent.handleMouseDown(event);
 			event.preventDefault();
 			event.stopPropagation();
@@ -87,7 +87,7 @@
 	<div class='draggable'
 		style={style}
 		bind:this={draggable}
-		on:mousedown={handle_mouseDown}
+		on:pointerdown={handle_pointerDown}
 		class:rubberband-active={$w_dragging_active}>
 		{#if $w_show_graph_ofType == T_Graph.radial}
 			<Radial_Graph/>


### PR DESCRIPTION
Prevent rubberband activation when clicking interactive graph elements by refining event handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-77ce41bc-b443-49e9-a906-c8afce263dc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77ce41bc-b443-49e9-a906-c8afce263dc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

